### PR TITLE
feat: processo de primeiro login a usuarios

### DIFF
--- a/6 - CÓDIGO BACKEND/repositorio_tcc/pom.xml
+++ b/6 - CÓDIGO BACKEND/repositorio_tcc/pom.xml
@@ -164,16 +164,19 @@
 			<version>5.4.0</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-ooxml</artifactId>
-			<version>5.2.3</version> <!-- Verifique a versão mais recente -->
-		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+				<configuration>
+					<source>21</source>
+					<target>21</target>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/config/SecurityConfig.java
+++ b/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/config/SecurityConfig.java
@@ -37,11 +37,14 @@ public class SecurityConfig {
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(
-                        authorizeHttpRequests -> authorizeHttpRequests
+                        authorize -> authorize
                                 .requestMatchers(
-                                        "/auth/*"
-                                ).permitAll()
-                                .requestMatchers("/api/v1/auth/**",
+                                        "/auth/login",
+                                        "/auth/register",
+                                        "/auth/sendPasswordReset",
+                                        "/auth/reset-password/**",
+                                        "/auth/first-access",
+                                        "/api/v1/auth/**",
                                         "/v3/api-docs/**",
                                         "/swagger-ui.html/**",
                                         "/h2-console/**",
@@ -55,8 +58,9 @@ public class SecurityConfig {
                                         "/configuration/ui",
                                         "/swagger-ui.html",
                                         "/webjars/**",
-                                        "/swagger-ui").permitAll().anyRequest().authenticated()
-
+                                        "/swagger-ui"
+                                ).permitAll()
+                                .anyRequest().authenticated()
                 )
                 .cors(cors -> {})
                 .build();

--- a/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/controller/AuthController.java
+++ b/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/controller/AuthController.java
@@ -37,9 +37,14 @@ public class AuthController {
         return authService.sendMailReset(request);
     }
 
-    @PatchMapping("/reset-password={token}")
+    @PatchMapping("/reset-password/{token}")
     public ResponseEntity<?> resetPassword(@PathVariable String token, @Valid @RequestBody ResetPasswordDTO request){
         return authService.resetPassword(request, token);
+    }
+
+    @PostMapping("/first-access")
+    public ResponseEntity<?> firstAcess(@RequestBody PrimeiroAcessoRequestDTO request) {
+        return authService.firstAccess(request);
     }
 
 }

--- a/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/dto/PrimeiroAcessoRequestDTO.java
+++ b/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/dto/PrimeiroAcessoRequestDTO.java
@@ -1,0 +1,6 @@
+package com.example.repositorioDeTcc.dto;
+
+import java.io.Serializable;
+
+public record PrimeiroAcessoRequestDTO(String matriculaOuCpf) implements Serializable {
+}

--- a/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/repository/AlunoRepository.java
+++ b/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/repository/AlunoRepository.java
@@ -4,11 +4,12 @@ import com.example.repositorioDeTcc.model.Aluno;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface AlunoRepository extends JpaRepository<Aluno, UUID> {
     public List<Aluno> findAllByAtivoIsTrue();
 
     public Boolean existsByMatriculaOrEmail(String matricula, String email);
-
+    public Optional<Aluno> findByMatricula(String matricula);
 }

--- a/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/repository/OrientadorRepository.java
+++ b/6 - CÓDIGO BACKEND/repositorio_tcc/src/main/java/com/example/repositorioDeTcc/repository/OrientadorRepository.java
@@ -5,8 +5,10 @@ import com.example.repositorioDeTcc.model.Orientador;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface OrientadorRepository extends JpaRepository<Orientador, UUID> {
     public List<Orientador> findAllByAtivoIsTrue();
+    public Optional<Orientador> findByCpf(String cpf);
 }


### PR DESCRIPTION
# Descrição

Adicionado o processo de primeiro login a usuários ainda não cadastrados no sistema. Para alunos, utilizar a matrícula. Para professores/orientadores, utilizar o CPF.

O endpoint sempre retorna 200 por questões de segurança, não é recomendado retornar dizendo se o usuário já logou antes ou não.

Caso o usuário receba, ele está elegível a fazer o primeiro acesso. É enviado um e-mail de boas vindas ao usuário com um link a ser definido a senha de acesso.